### PR TITLE
feat(clients/node): add mockly-node — Node.js client package

### DIFF
--- a/clients/node/.gitignore
+++ b/clients/node/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/clients/node/README.md
+++ b/clients/node/README.md
@@ -1,0 +1,243 @@
+# mockly-node
+
+Node.js client for [Mockly](https://github.com/dever-labs/mockly) — start, stop, and control Mockly HTTP mock servers from Node.js test suites.
+
+```ts
+import { MocklyServer } from 'mockly-node'
+
+const server = await MocklyServer.ensure() // install binary if needed, then start
+
+await server.addMock({
+  id: 'get-users',
+  request: { method: 'GET', path: '/users' },
+  response: { status: 200, body: '[{"id":1}]', headers: { 'Content-Type': 'application/json' } },
+})
+
+const res = await fetch(`${server.httpBase}/users`)
+// → 200 [{"id":1}]
+
+await server.stop()
+```
+
+## Installation
+
+```sh
+npm install --save-dev mockly-node
+```
+
+The Mockly binary is **not** bundled in the npm package. Download it once before running tests:
+
+```sh
+npx mockly-node-install
+```
+
+Or let `MocklyServer.ensure()` handle it automatically on first run.
+
+---
+
+## Usage
+
+### `MocklyServer.ensure(opts?)` _(recommended)_
+
+Downloads the binary if missing, then starts the server.
+
+```ts
+const server = await MocklyServer.ensure()
+```
+
+### `MocklyServer.create(opts?)`
+
+Starts the server using an already-installed binary. Throws if the binary is not found.
+
+```ts
+const server = await MocklyServer.create()
+```
+
+### Test framework integration
+
+```ts
+// vitest / jest
+import { MocklyServer } from 'mockly-node'
+
+let server: MocklyServer
+
+beforeAll(async () => {
+  server = await MocklyServer.ensure()
+}, 30_000)
+
+afterAll(() => server?.stop())
+
+beforeEach(() => server.reset()) // isolate each test
+
+it('returns 200', async () => {
+  await server.addMock({
+    id: 'ping',
+    request: { method: 'GET', path: '/ping' },
+    response: { status: 200, body: 'pong' },
+  })
+  const res = await fetch(`${server.httpBase}/ping`)
+  expect(res.status).toBe(200)
+})
+```
+
+---
+
+## Management API
+
+### `server.addMock(mock)`
+
+Adds an HTTP mock. Mocks are matched in insertion order — first match wins.
+
+```ts
+await server.addMock({
+  id: 'create-user',
+  request: {
+    method: 'POST',
+    path: '/users',
+    headers: { Authorization: 'Bearer mytoken' }, // exact match
+  },
+  response: {
+    status: 201,
+    body: '{"id":42}',
+    headers: { 'Content-Type': 'application/json' },
+    delay: '50ms',
+  },
+})
+```
+
+> **Note:** Header matching is exact. Place mocks with header constraints _before_ less-specific fallbacks.
+
+### `server.deleteMock(id)`
+
+Removes a mock by id.
+
+### `server.reset()`
+
+Removes all dynamically added mocks, deactivates scenarios, and clears fault injection. Mocks defined in startup config are preserved. Call in `beforeEach` to keep tests isolated.
+
+### Scenarios
+
+Scenarios override mock responses when activated — useful for simulating outage modes.
+
+```ts
+const server = await MocklyServer.ensure({
+  scenarios: [
+    {
+      id: 'auth-down',
+      name: 'Auth service unavailable',
+      patches: [{ mock_id: 'token-endpoint', status: 503, body: '{"error":"down"}' }],
+    },
+  ],
+})
+
+await server.addMock({
+  id: 'token-endpoint',
+  request: { method: 'POST', path: '/token' },
+  response: { status: 200, body: '{"access_token":"abc"}' },
+})
+
+// Normal operation
+const r1 = await fetch(`${server.httpBase}/token`, { method: 'POST' })
+// → 200
+
+await server.activateScenario('auth-down')
+
+const r2 = await fetch(`${server.httpBase}/token`, { method: 'POST' })
+// → 503
+
+await server.deactivateScenario('auth-down')
+```
+
+### Fault injection
+
+```ts
+// Delay every response by 200 ms
+await server.setFault({ enabled: true, delay: '200ms' })
+
+// Override all responses with 503
+await server.setFault({ enabled: true, status_override: 503 })
+
+// Randomly fail 30% of requests
+await server.setFault({ enabled: true, status_override: 503, error_rate: 0.3 })
+
+await server.clearFault()
+```
+
+---
+
+## Binary installation
+
+### Default (download from GitHub)
+
+```sh
+npx mockly-node-install
+```
+
+Or programmatically:
+
+```ts
+import { install } from 'mockly-node'
+await install()
+```
+
+### Artifactory / internal mirror
+
+Set `MOCKLY_DOWNLOAD_BASE_URL` to your mirror's base URL (the path up to and including the version segment prefix):
+
+```sh
+MOCKLY_DOWNLOAD_BASE_URL=https://artifactory.company.com/artifactory/github-releases/dever-labs/mockly/releases/download \
+  npx mockly-node-install
+```
+
+Artifactory setup: create a **Generic Remote Repository** pointing to `https://github.com` and enable "Store Artifacts Locally". The download URL then becomes `https://<artifactory>/artifactory/<repo>/dever-labs/mockly/releases/download`.
+
+### HTTP / HTTPS proxy
+
+Set `HTTPS_PROXY` or `HTTP_PROXY` before running the install:
+
+```sh
+HTTPS_PROXY=https://proxy.company.com:3128 npx mockly-node-install
+```
+
+Proxy authentication is supported via the proxy URL: `https://user:pass@proxy:3128`.
+
+> **Tip:** For Artifactory, `MOCKLY_DOWNLOAD_BASE_URL` is simpler and more reliable than `HTTPS_PROXY`.
+
+### Air-gapped environments
+
+Pre-stage the binary and point to it:
+
+```sh
+# On a machine with internet access:
+npx mockly-node-install
+
+# Copy bin/mockly[.exe] to the air-gapped machine, then:
+MOCKLY_BINARY_PATH=/opt/tools/mockly npx vitest run
+```
+
+Or set `MOCKLY_NO_INSTALL=true` to make the binary absence a hard error with actionable instructions:
+
+```sh
+MOCKLY_NO_INSTALL=true npx vitest run  # fails fast if binary not staged
+```
+
+### Environment variable reference
+
+| Variable | Description |
+|---|---|
+| `MOCKLY_BINARY_PATH` | Absolute path to a pre-existing binary. Skips all download logic. |
+| `MOCKLY_DOWNLOAD_BASE_URL` | Base URL override for binary downloads (Artifactory / mirrors). |
+| `MOCKLY_VERSION` | Binary version to install. Default: `v0.1.0`. |
+| `MOCKLY_NO_INSTALL` | If set, fail with instructions instead of downloading. |
+| `HTTPS_PROXY` / `HTTP_PROXY` | Route downloads through an HTTP proxy (supports CONNECT). |
+
+---
+
+## Requirements
+
+- Node.js ≥ 18
+- Platforms: Linux (x64/arm64), macOS (x64/arm64), Windows (x64)
+
+## License
+
+MIT

--- a/clients/node/bin/install.mjs
+++ b/clients/node/bin/install.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for installing the Mockly binary.
+ *
+ * Usage:
+ *   node node_modules/mockly-node/bin/install.mjs
+ *   npx mockly-node-install
+ *
+ * Options (via environment variables):
+ *   MOCKLY_VERSION            Override binary version (default: bundled default)
+ *   MOCKLY_DOWNLOAD_BASE_URL  Override base download URL (Artifactory / mirrors)
+ *   MOCKLY_BINARY_PATH        Use a pre-existing binary at this path
+ *   MOCKLY_NO_INSTALL         Fail with instructions instead of downloading
+ *   HTTPS_PROXY / HTTP_PROXY  Route download through HTTP proxy
+ */
+
+import { install } from '../dist/install.js'
+
+try {
+  const binPath = await install({ force: process.argv.includes('--force') })
+  process.stdout.write(`mockly binary ready at ${binPath}\n`)
+} catch (err) {
+  process.stderr.write(`\nmockly-node install failed:\n${err.message}\n\n`)
+  process.exit(1)
+}

--- a/clients/node/package-lock.json
+++ b/clients/node/package-lock.json
@@ -1,0 +1,83 @@
+{
+  "name": "mockly-node",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mockly-node",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "mockly-node-install": "bin/install.mjs"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/clients/node/package.json
+++ b/clients/node/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "mockly-node",
+  "version": "0.1.0",
+  "description": "Node.js client for Mockly — start/stop servers and manage HTTP mocks in tests",
+  "keywords": ["mock", "testing", "http", "integration-test", "mockly", "test-server"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dever-labs/mockly.git",
+    "directory": "clients/node"
+  },
+  "bugs": {
+    "url": "https://github.com/dever-labs/mockly/issues"
+  },
+  "homepage": "https://github.com/dever-labs/mockly/tree/main/clients/node#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "bin": {
+    "mockly-node-install": "./bin/install.mjs"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/clients/node/src/index.ts
+++ b/clients/node/src/index.ts
@@ -1,0 +1,13 @@
+export { MocklyServer } from './server.js'
+export { install, getBinaryPath, DEFAULT_MOCKLY_VERSION } from './install.js'
+export { getFreePort } from './utils.js'
+export type {
+  HttpMock,
+  MockRequest,
+  MockResponse,
+  Scenario,
+  ScenarioPatch,
+  FaultConfig,
+  MocklyServerOptions,
+} from './types.js'
+export type { InstallOptions } from './install.js'

--- a/clients/node/src/install.ts
+++ b/clients/node/src/install.ts
@@ -1,0 +1,266 @@
+import http from 'http'
+import https from 'https'
+import tls from 'tls'
+import { createWriteStream, existsSync, mkdirSync, chmodSync } from 'fs'
+import { join, resolve } from 'path'
+
+/** Version of the Mockly binary this package was tested against. */
+export const DEFAULT_MOCKLY_VERSION = 'v0.1.0'
+
+/** Default GitHub releases base URL. */
+const GITHUB_BASE = 'https://github.com/dever-labs/mockly/releases/download'
+
+export interface InstallOptions {
+  /**
+   * Mockly version to install.
+   * @default process.env.MOCKLY_VERSION ?? DEFAULT_MOCKLY_VERSION
+   */
+  version?: string
+
+  /**
+   * Base URL for downloading release assets.
+   *
+   * Override this to route downloads through Artifactory or an internal mirror:
+   * ```
+   * MOCKLY_DOWNLOAD_BASE_URL=https://artifactory.company.com/artifactory/github-releases/dever-labs/mockly/releases/download
+   * ```
+   * The full download URL becomes `${baseUrl}/${version}/${assetName}`.
+   *
+   * @default process.env.MOCKLY_DOWNLOAD_BASE_URL ?? GitHub releases URL
+   */
+  baseUrl?: string
+
+  /**
+   * Directory to place the downloaded binary.
+   * @default path.join(process.cwd(), 'bin')
+   */
+  binDir?: string
+
+  /**
+   * Re-download even if the binary already exists.
+   * @default false
+   */
+  force?: boolean
+}
+
+/**
+ * Returns the path to the installed binary, or `null` if not found.
+ *
+ * Resolution order:
+ * 1. `MOCKLY_BINARY_PATH` env var (absolute path to pre-staged binary)
+ * 2. `<binDir>/mockly[.exe]` (downloaded by `install()`)
+ * 3. `<cwd>/node_modules/.bin/mockly[.exe]` (future: native npm wrapper)
+ */
+export function getBinaryPath(binDir?: string): string | null {
+  const ext = process.platform === 'win32' ? '.exe' : ''
+
+  if (process.env.MOCKLY_BINARY_PATH) {
+    const p = resolve(process.env.MOCKLY_BINARY_PATH)
+    if (existsSync(p)) return p
+  }
+
+  const dir = binDir ?? join(process.cwd(), 'bin')
+  const fromBinDir = join(dir, `mockly${ext}`)
+  if (existsSync(fromBinDir)) return fromBinDir
+
+  const fromModules = resolve(process.cwd(), 'node_modules', '.bin', `mockly${ext}`)
+  if (existsSync(fromModules)) return fromModules
+
+  return null
+}
+
+/**
+ * Downloads (or locates) the Mockly binary and returns its path.
+ *
+ * Environment variables (all optional):
+ * - `MOCKLY_BINARY_PATH`       — use this exact binary; skips all download logic
+ * - `MOCKLY_NO_INSTALL`        — throw instead of downloading (for air-gapped envs
+ *                                 where the binary is staged externally)
+ * - `MOCKLY_DOWNLOAD_BASE_URL` — base URL override for Artifactory / internal mirrors
+ * - `MOCKLY_VERSION`           — binary version override
+ * - `HTTPS_PROXY` / `HTTP_PROXY` — route the download through an HTTP proxy
+ *
+ * @returns Absolute path to the installed binary.
+ */
+export async function install(opts: InstallOptions = {}): Promise<string> {
+  const ext = process.platform === 'win32' ? '.exe' : ''
+  const binDir = opts.binDir ?? join(process.cwd(), 'bin')
+  const binPath = join(binDir, `mockly${ext}`)
+
+  // 1. MOCKLY_BINARY_PATH — use a pre-staged binary without downloading
+  if (process.env.MOCKLY_BINARY_PATH) {
+    const staged = resolve(process.env.MOCKLY_BINARY_PATH)
+    if (!existsSync(staged)) {
+      throw new Error(
+        `MOCKLY_BINARY_PATH is set to "${staged}" but the file does not exist.\n` +
+        `Stage the binary for platform "${process.platform}/${process.arch}" before running tests.`
+      )
+    }
+    return staged
+  }
+
+  // 2. Already installed — skip unless force
+  if (!opts.force && existsSync(binPath)) {
+    return binPath
+  }
+
+  // 3. MOCKLY_NO_INSTALL — fail fast with actionable instructions
+  if (process.env.MOCKLY_NO_INSTALL) {
+    throw new Error(
+      `MOCKLY_NO_INSTALL is set but no Mockly binary was found.\n\n` +
+      `To resolve this, choose one of:\n` +
+      `  a) Stage the binary manually:\n` +
+      `       Place the binary at: ${binPath}\n` +
+      `       Download from: https://github.com/dever-labs/mockly/releases\n\n` +
+      `  b) Set MOCKLY_BINARY_PATH to the absolute path of an existing binary.\n\n` +
+      `  c) Use MOCKLY_DOWNLOAD_BASE_URL to point to an internal mirror:\n` +
+      `       MOCKLY_DOWNLOAD_BASE_URL=https://artifactory.company.com/artifactory/github-releases/dever-labs/mockly/releases/download`
+    )
+  }
+
+  // 4. Download
+  const version = opts.version ?? process.env.MOCKLY_VERSION ?? DEFAULT_MOCKLY_VERSION
+  const baseUrl = opts.baseUrl ?? process.env.MOCKLY_DOWNLOAD_BASE_URL ?? GITHUB_BASE
+  const asset = getAssetName()
+  const url = `${baseUrl}/${version}/${asset}`
+
+  mkdirSync(binDir, { recursive: true })
+
+  console.log(`mockly-node: downloading ${asset} from ${url}`)
+  await downloadFile(url, binPath)
+
+  if (process.platform !== 'win32') {
+    chmodSync(binPath, 0o755)
+  }
+
+  console.log(`mockly-node: installed at ${binPath}`)
+  return binPath
+}
+
+// ─── Asset name ───────────────────────────────────────────────────────────────
+
+const ARCH_MAP: Record<string, string> = {
+  x64: 'amd64',
+  arm64: 'arm64',
+}
+
+function getAssetName(): string {
+  const os = process.platform === 'win32' ? 'windows'
+    : process.platform === 'darwin' ? 'darwin'
+    : 'linux'
+
+  const arch = ARCH_MAP[process.arch]
+  if (!arch) {
+    throw new Error(
+      `Unsupported architecture: ${process.arch}.\n` +
+      `Supported: x64 (amd64), arm64.\n` +
+      `For other platforms, build from source: https://github.com/dever-labs/mockly`
+    )
+  }
+
+  return `mockly-${os}-${arch}${process.platform === 'win32' ? '.exe' : ''}`
+}
+
+// ─── Download ─────────────────────────────────────────────────────────────────
+
+function getProxyUrl(): string | undefined {
+  return (
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.npm_config_https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy ??
+    process.env.npm_config_proxy
+  )
+}
+
+function downloadFile(url: string, dest: string): Promise<void> {
+  const proxyUrl = getProxyUrl()
+  return proxyUrl ? downloadViaProxy(url, dest, proxyUrl) : downloadDirect(url, dest)
+}
+
+function downloadDirect(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const get = (u: string) => {
+      https.get(u, { headers: { 'User-Agent': 'mockly-node-install' } }, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          get(res.headers.location!)
+          return
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} from ${u}`))
+          return
+        }
+        const ws = createWriteStream(dest)
+        res.pipe(ws)
+        ws.on('finish', resolve)
+        ws.on('error', reject)
+      }).on('error', reject)
+    }
+    get(url)
+  })
+}
+
+/**
+ * Downloads via HTTP CONNECT proxy (for environments where HTTPS_PROXY /
+ * HTTP_PROXY is set but MOCKLY_DOWNLOAD_BASE_URL cannot be used).
+ *
+ * For Artifactory, prefer setting MOCKLY_DOWNLOAD_BASE_URL instead — it is
+ * simpler and avoids CONNECT tunnel complexity.
+ */
+function downloadViaProxy(targetUrl: string, dest: string, proxyUrl: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(targetUrl)
+    const proxy = new URL(proxyUrl)
+
+    const connectOpts: http.RequestOptions = {
+      host: proxy.hostname,
+      port: parseInt(proxy.port) || 3128,
+      method: 'CONNECT',
+      path: `${target.hostname}:443`,
+      headers: {},
+    }
+
+    if (proxy.username) {
+      const auth = Buffer.from(`${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`).toString('base64')
+      ;(connectOpts.headers as Record<string, string>)['Proxy-Authorization'] = `Basic ${auth}`
+    }
+
+    const connectReq = http.request(connectOpts)
+
+    connectReq.on('connect', (_res, socket) => {
+      // Wrap the plain socket in TLS to complete the HTTPS tunnel
+      const tlsSocket = tls.connect({ socket, servername: target.hostname })
+
+      const req = https.request(
+        {
+          createConnection: () => tlsSocket,
+          hostname: target.hostname,
+          path: target.pathname + target.search,
+          method: 'GET',
+          headers: { 'User-Agent': 'mockly-node-install' },
+        },
+        (res) => {
+          if (res.statusCode === 301 || res.statusCode === 302) {
+            tlsSocket.destroy()
+            downloadViaProxy(res.headers.location!, dest, proxyUrl).then(resolve).catch(reject)
+            return
+          }
+          if (res.statusCode !== 200) {
+            reject(new Error(`HTTP ${res.statusCode} from ${targetUrl} (via proxy ${proxyUrl})`))
+            return
+          }
+          const ws = createWriteStream(dest)
+          res.pipe(ws)
+          ws.on('finish', resolve)
+          ws.on('error', reject)
+        }
+      )
+      req.on('error', reject)
+      req.end()
+    })
+
+    connectReq.on('error', reject)
+    connectReq.end()
+  })
+}

--- a/clients/node/src/server.ts
+++ b/clients/node/src/server.ts
@@ -1,0 +1,218 @@
+import { spawn, ChildProcess } from 'child_process'
+import { writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import yaml from 'js-yaml'
+import type { HttpMock, Scenario, FaultConfig, MocklyServerOptions } from './types.js'
+import type { InstallOptions } from './install.js'
+import { install, getBinaryPath } from './install.js'
+import { getFreePort, sleep } from './utils.js'
+
+/**
+ * Controls a Mockly server process for use in integration tests.
+ *
+ * @example
+ * ```ts
+ * // Recommended: ensure binary is installed, then start
+ * const server = await MocklyServer.ensure()
+ *
+ * await server.addMock({
+ *   id: 'get-users',
+ *   request: { method: 'GET', path: '/users' },
+ *   response: { status: 200, body: '[{"id":1}]', headers: { 'Content-Type': 'application/json' } },
+ * })
+ *
+ * // Point your HTTP client at server.httpBase
+ * const res = await fetch(`${server.httpBase}/users`)
+ *
+ * await server.stop()
+ * ```
+ */
+export class MocklyServer {
+  private proc: ChildProcess | null = null
+
+  private constructor(
+    readonly httpPort: number,
+    readonly apiPort: number,
+  ) {}
+
+  /** Base URL of the HTTP mock server — e.g. `http://127.0.0.1:45123` */
+  get httpBase(): string { return `http://127.0.0.1:${this.httpPort}` }
+
+  /** Base URL of the management API — e.g. `http://127.0.0.1:45124` */
+  get apiBase(): string { return `http://127.0.0.1:${this.apiPort}` }
+
+  /**
+   * Installs the Mockly binary if it is not already present, then starts the
+   * server. This is the recommended entry point for most test setups.
+   *
+   * Respects all `InstallOptions` and their corresponding environment
+   * variables — see {@link install} for details.
+   */
+  static async ensure(opts: MocklyServerOptions & InstallOptions = {}): Promise<MocklyServer> {
+    if (!getBinaryPath(opts.binDir)) {
+      await install(opts)
+    }
+    return MocklyServer.create(opts)
+  }
+
+  /**
+   * Starts the server using an already-installed binary.
+   * Throws immediately if the binary cannot be found — call `ensure()` instead
+   * if you want automatic installation.
+   *
+   * Ports are allocated sequentially to avoid TOCTOU races.
+   * If startup fails, the spawned process is killed before the error is thrown.
+   */
+  static async create(opts: MocklyServerOptions = {}): Promise<MocklyServer> {
+    const httpPort = await getFreePort()
+    const apiPort = await getFreePort()
+    const server = new MocklyServer(httpPort, apiPort)
+    try {
+      await server._start(opts.scenarios ?? [])
+    } catch (err) {
+      await server.stop()
+      throw err
+    }
+    return server
+  }
+
+  /** Kills the Mockly process and waits for it to exit. */
+  async stop(): Promise<void> {
+    if (this.proc) {
+      this.proc.kill()
+      await new Promise<void>((r) => this.proc!.once('exit', r))
+      this.proc = null
+    }
+  }
+
+  // ── Management API ──────────────────────────────────────────────────────────
+
+  /**
+   * Registers a new HTTP mock via the management API.
+   * Mocks are matched in insertion order — the first match wins.
+   *
+   * **Header matching** uses exact string comparison.
+   * Place more-specific mocks (with header requirements) before less-specific
+   * fallbacks to ensure correct priority.
+   */
+  async addMock(mock: HttpMock): Promise<void> {
+    const res = await this._post('/api/mocks/http', mock)
+    if (!res.ok) throw new Error(`addMock(${mock.id}) failed: HTTP ${res.status}`)
+  }
+
+  /** Removes a mock by id. */
+  async deleteMock(id: string): Promise<void> {
+    await fetch(`${this.apiBase}/api/mocks/http/${id}`, { method: 'DELETE' })
+  }
+
+  /**
+   * Activates a named scenario, patching the responses of referenced mocks.
+   * The scenario must have been declared in `MocklyServerOptions.scenarios`.
+   */
+  async activateScenario(id: string): Promise<void> {
+    const res = await this._post(`/api/scenarios/${id}/activate`, null)
+    if (!res.ok) throw new Error(`activateScenario(${id}) failed: HTTP ${res.status}`)
+  }
+
+  /** Deactivates a previously activated scenario. */
+  async deactivateScenario(id: string): Promise<void> {
+    await fetch(`${this.apiBase}/api/scenarios/${id}/activate`, { method: 'DELETE' })
+  }
+
+  /**
+   * Enables global fault injection.
+   * Faults apply to every request regardless of mock matching.
+   */
+  async setFault(config: FaultConfig): Promise<void> {
+    const res = await this._post('/api/fault', config)
+    if (!res.ok) throw new Error(`setFault failed: HTTP ${res.status}`)
+  }
+
+  /** Disables all active fault injection. */
+  async clearFault(): Promise<void> {
+    await fetch(`${this.apiBase}/api/fault`, { method: 'DELETE' })
+  }
+
+  /**
+   * Resets all state: removes dynamically added mocks, deactivates scenarios,
+   * and clears fault injection. Mocks from the startup config are preserved.
+   *
+   * Call this in `beforeEach` to keep tests isolated.
+   */
+  async reset(): Promise<void> {
+    await this._post('/api/reset', null)
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  private async _start(scenarios: Scenario[]): Promise<void> {
+    const bin = getBinaryPath()
+    if (!bin) {
+      throw new Error(
+        'Mockly binary not found. Use `MocklyServer.ensure()` instead of ' +
+        '`MocklyServer.create()` to install automatically, or call `install()` first.\n' +
+        'For pre-staged binaries set MOCKLY_BINARY_PATH to the absolute path.'
+      )
+    }
+
+    const cfgPath = this._writeConfig(scenarios)
+
+    this.proc = spawn(bin, ['start', '--config', cfgPath, `--api-port=${this.apiPort}`], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    this.proc.on('error', (err) => { throw new Error(`mockly spawn error: ${err.message}`) })
+
+    await this._waitReady()
+  }
+
+  private _writeConfig(scenarios: Scenario[]): string {
+    const dir = join(tmpdir(), `mockly-node-${Date.now()}`)
+    mkdirSync(dir, { recursive: true })
+    const cfgPath = join(dir, 'mockly.yaml')
+
+    const config: Record<string, unknown> = {
+      mockly: { api: { port: this.apiPort } },
+      protocols: { http: { enabled: true, port: this.httpPort } },
+    }
+
+    if (scenarios.length > 0) {
+      config.scenarios = scenarios.map((s) => ({
+        id: s.id,
+        name: s.name,
+        patches: s.patches.map((p) => {
+          const patch: Record<string, unknown> = { mock_id: p.mock_id }
+          if (p.status !== undefined) patch.status = p.status
+          if (p.body !== undefined) patch.body = p.body
+          if (p.delay !== undefined) patch.delay = p.delay
+          return patch
+        }),
+      }))
+    }
+
+    writeFileSync(cfgPath, yaml.dump(config), 'utf-8')
+    return cfgPath
+  }
+
+  private async _waitReady(maxMs = 10_000): Promise<void> {
+    const deadline = Date.now() + maxMs
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(`${this.apiBase}/api/protocols`, {
+          signal: AbortSignal.timeout(300),
+        })
+        if (res.ok) return
+      } catch { /* not ready yet */ }
+      await sleep(50)
+    }
+    throw new Error(`Mockly did not become ready on port ${this.apiPort} within ${maxMs}ms`)
+  }
+
+  private _post(path: string, body: unknown): Promise<Response> {
+    return fetch(`${this.apiBase}${path}`, {
+      method: 'POST',
+      headers: body !== null ? { 'Content-Type': 'application/json' } : {},
+      body: body !== null ? JSON.stringify(body) : undefined,
+    })
+  }
+}

--- a/clients/node/src/types.ts
+++ b/clients/node/src/types.ts
@@ -1,0 +1,59 @@
+/** Request matching criteria for an HTTP mock. */
+export interface MockRequest {
+  method: string
+  path: string
+  /** Exact header value matching — e.g. `{ Authorization: 'Bearer token123' }` */
+  headers?: Record<string, string>
+}
+
+/** Response definition for an HTTP mock. */
+export interface MockResponse {
+  status: number
+  body?: string
+  headers?: Record<string, string>
+  /** Artificial delay — e.g. `'100ms'`, `'1s'` */
+  delay?: string
+}
+
+/** A full HTTP mock definition. */
+export interface HttpMock {
+  id: string
+  request: MockRequest
+  response: MockResponse
+}
+
+/** A single patch applied when a scenario is activated. */
+export interface ScenarioPatch {
+  mock_id: string
+  status?: number
+  body?: string
+  delay?: string
+}
+
+/** A named scenario that patches one or more mock responses when activated. */
+export interface Scenario {
+  id: string
+  name: string
+  patches: ScenarioPatch[]
+}
+
+/** Global fault injection configuration. */
+export interface FaultConfig {
+  enabled: boolean
+  /** Artificial delay added to every request — e.g. `'200ms'` */
+  delay?: string
+  /** Override the HTTP status of every matched response */
+  status_override?: number
+  /** Probability (0–1) that the override fires; 0 means always */
+  error_rate?: number
+}
+
+/** Options accepted by `MocklyServer.create()`. */
+export interface MocklyServerOptions {
+  /**
+   * Scenarios to include in the startup config.
+   * Scenarios can only be activated/deactivated via the management API;
+   * they cannot be created dynamically after the server starts.
+   */
+  scenarios?: Scenario[]
+}

--- a/clients/node/src/utils.ts
+++ b/clients/node/src/utils.ts
@@ -1,0 +1,20 @@
+import net from 'net'
+
+/**
+ * Returns a free TCP port on 127.0.0.1.
+ * Always allocate ports sequentially, never in parallel, to avoid TOCTOU
+ * races where two concurrent calls could receive the same port.
+ */
+export function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}

--- a/clients/node/tsconfig.json
+++ b/clients/node/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Superseded by a dedicated repo: dever-labs/mockly-driver