### PR TITLE
chore(deps): batch dependency updates 2026-04-26

### DIFF
--- a/clients/node/package-lock.json
+++ b/clients/node/package-lock.json
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Batch Dependency Updates — 2026-04-26

This PR combines 1 Dependabot PRs below the auto-merge threshold (8.0):

- #42: chore(deps-dev): Bump postcss from 8.5.8 to 8.5.10 in /clients/node in the npm_and_yarn group across 1 directory

Reviewed and batched by openclaw pr-review CronJob.