### PR TITLE
fix: install Copilot CLI and Claude Code in devcontainer init

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -6,6 +6,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+echo -e "${CYAN}==> Installing Copilot CLI and Claude Code...${NC}"
+npm install -g @github/copilot @anthropic-ai/claude-code
+sudo ln -sf "$(npm prefix -g)/bin/copilot" /usr/local/bin/copilot
+sudo ln -sf "$(npm prefix -g)/bin/claude" /usr/local/bin/claude
+
 echo -e "${CYAN}==> Installing Go tools...${NC}"
 GOTOOLCHAIN=auto go install github.com/air-verse/air@v1.61.7
 GOTOOLCHAIN=auto go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
@@ -32,6 +37,6 @@ echo -e ""
 if ls ~/.copilot/*.json &>/dev/null 2>&1; then
   echo -e "${GREEN}✔ GitHub Copilot CLI authenticated.${NC}"
 else
-  echo -e "Run ${YELLOW}copilot login${NC} to authenticate GitHub Copilot CLI."
+  echo -e "Run ${YELLOW}copilot auth login${NC} to authenticate GitHub Copilot CLI."
   echo -e "Credentials persist in a Docker volume — no re-login needed after rebuild."
 fi


### PR DESCRIPTION
## Problem
When a service repo defines its own `postCreateCommand` (like `bash .devcontainer/init.sh`), it overrides the `go-dev` image's embedded metadata lifecycle script — so `@github/copilot` and `@anthropic-ai/claude-code` were never installed. The `copilot` and `claude` commands were missing in the container.

## Fix
Install Copilot CLI and Claude Code at the top of `init.sh`, following the same pattern as `images/frontend-dev/init.sh` in the devcontainers repo. Also corrects the auth hint from `copilot login` → `copilot auth login`.